### PR TITLE
Fix link to for "more" from Teach with Orange

### DIFF
--- a/public/home/[slug]/orange_users/index.md
+++ b/public/home/[slug]/orange_users/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Orange users"
+title: "Teach with Orange"
 weight: 40
 ---
 


### PR DESCRIPTION
Our frontpage's links are influenced by section titles, which I did not account for (and I think it should not be that way).