### PR TITLE
Add md attribute to set image width

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.47.0",
     "react-icons": "^4.11.0",
+    "rehype-attr": "^4.0.2",
     "rehype-highlight": "^7.0.0",
     "remark-gfm": "^3.0.1",
     "remark-unwrap-images": "^3.0.1",
@@ -65,8 +66,8 @@
     "cypress": "^11.2.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
-    "prettier": "^3.0.3",
     "imagemin-mozjpeg": "^10.0.0",
-    "imagemin-pngquant": "^9.0.2"
+    "imagemin-pngquant": "^9.0.2",
+    "prettier": "^3.0.3"
   }
 }

--- a/utils/images/getImageData.tsx
+++ b/utils/images/getImageData.tsx
@@ -63,13 +63,14 @@ export function getImageData(this: Processor) {
     });
 
     for (let node of imageNodes) {
+      const givenWidth = node.properties.width;
       const imageDate = getOptimizedImageAttributes(node.properties.src);
 
       if (imageDate) {
         node.properties = {
           ...node.properties,
-          width: imageDate.width,
-          height: imageDate.height,
+          width: givenWidth || imageDate.width,
+          height: givenWidth ? imageDate.height * (givenWidth /imageDate.width) : imageDate.height,
           src: imageDate.src,
         };
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4903,6 +4903,14 @@ regexpp@^3.2.0:
   resolved "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+rehype-attr@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/rehype-attr/-/rehype-attr-4.0.2.tgz#95ccd19acd2a8ec9adf8b3ea0f27667463c23f0e"
+  integrity sha512-v4+gw7pvUVLbG/dUpLgBE6r3TWTBYJ7z+sfAH3zapmM5CKzk5+CopFQgr4gMR6OBSKl/qpI6HR7gv1Cbig0uow==
+  dependencies:
+    unified "~11.0.0"
+    unist-util-visit "~5.0.0"
+
 rehype-highlight@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/rehype-highlight/-/rehype-highlight-7.0.0.tgz#f2fd0eaebea7d4d4ce2fca2e8d9e3aea9441aefc"
@@ -5703,6 +5711,19 @@ unified@^10.0.0:
     trough "^2.0.0"
     vfile "^5.0.0"
 
+unified@~11.0.0:
+  version "11.0.5"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-11.0.5.tgz#f66677610a5c0a9ee90cab2b8d4d66037026d9e1"
+  integrity sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    bail "^2.0.0"
+    devlop "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^4.0.0"
+    trough "^2.0.0"
+    vfile "^6.0.0"
+
 unist-builder@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.0.tgz"
@@ -5796,7 +5817,7 @@ unist-util-visit@^4.0.0:
     unist-util-is "^5.0.0"
     unist-util-visit-parents "^5.1.1"
 
-unist-util-visit@^5.0.0:
+unist-util-visit@^5.0.0, unist-util-visit@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-5.0.0.tgz#a7de1f31f72ffd3519ea71814cccf5fd6a9217d6"
   integrity sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==


### PR DESCRIPTION
This PR allows to set the width for images in documentation for widgets, e.g.

```
![](/widget-catalog/data/images/SQLTable-stamped.png){width="70%"}
```

or 

```
![](/widget-catalog/data/images/Datasets-stamped.png){width="300"}
```

This syntax is used because it is supported by myst, which we use as a sphinx plugin for building the docs.

A regex is used to replace the above with `![](/widget-catalog/data/images/Datasets-stamped.png)<!--rehype:width="300"-->`, which is a syntax handled by the rehype-attr plugin. I would prefer using remark-attr that supports myst's syntax directly, but remark-attr hasn't been touched since 2020 and no longer works. An alternative would be to reimplement remart-attr on our own ... but this approach is simpler.

Furthermore, the PR modifies `getImageData` to respect the manually set width (and scale the height correspondingly).